### PR TITLE
Call super method with method arguments if no arguments are specified.

### DIFF
--- a/ring.js
+++ b/ring.js
@@ -115,8 +115,11 @@ function declare(_) {
                 return p;
             return (function(sup) {
                 return function() {
+                    var args = arguments;
                     var tmp = this.$super;
-                    this.$super = sup;
+                    this.$super = function() {
+                      return sup.apply(this, arguments.length ? arguments : args);
+                    };
                     var ret = p.apply(this, arguments);
                     this.$super = tmp;
                     return ret;

--- a/test.js
+++ b/test.js
@@ -29,6 +29,16 @@ test("objectSuper", function() {
     equal(new D().b, "b");
 });
 
+test("instanceSuper", function () {
+  var A = ring.create({
+    x: function(a) { return a; }
+  });
+  var B = ring.create([A], {
+    x: function(a) { return this.$super() + a; }
+  });
+  equal(new B().x(5), 10);
+});
+
 test("mro", function() {
     var f = ring.create([], {});
     deepEqual(f.__mro__, [f, ring.Object]);


### PR DESCRIPTION
Many modern languages with the super keyword call the super method with the called method's arguments unless otherwise specified. Coffeescript and Ruby do this and it is very handy.

Example:

``` javascript
  var B = ring.create([A], {
    x: function(a) { return this.$super() + a; }
  });
```

Since I didn't specify arguments in the this.$super() call, I want it to call the super method with the arguments [a].
